### PR TITLE
Streamで音声データを出力するAPIを追加

### DIFF
--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -302,7 +302,19 @@ namespace Speech
 
         public SoundStream ExportToStream(string text)
         {
-            throw new NotImplementedException();
+            _ttsControl.Text = text;
+
+            var filePath = Path.Combine(Path.GetTempPath(), $"{this.GetType().Name}_{(uint)text.GetHashCode()}.wav");
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+            _ttsControl.SaveAudioToFile(filePath);
+            if(File.Exists(filePath))
+            {
+                return SoundStream.Open(filePath);
+            }
+            return null;
         }
 
         #region IDisposable Support

--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -300,6 +300,24 @@ namespace Speech
             return GetMaster().PitchRange;
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -301,14 +301,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -304,7 +304,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -313,7 +313,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -300,11 +300,6 @@ namespace Speech
             return GetMaster().PitchRange;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             throw new NotImplementedException();

--- a/src/Speech/Controller/AIVOICEController.cs
+++ b/src/Speech/Controller/AIVOICEController.cs
@@ -300,7 +300,7 @@ namespace Speech
             return GetMaster().PitchRange;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/CeVIO64Controller.cs
+++ b/src/Speech/Controller/CeVIO64Controller.cs
@@ -258,7 +258,7 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             string tempFile = Path.GetTempFileName();
             if (_talker.OutputWaveToFile(text, tempFile))

--- a/src/Speech/Controller/CeVIO64Controller.cs
+++ b/src/Speech/Controller/CeVIO64Controller.cs
@@ -258,6 +258,29 @@ namespace Speech
             return _talker.Alpha;
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotSupportedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            string tempFile = Path.GetTempFileName();
+            if (_talker.OutputWaveToFile(text, tempFile))
+            {
+                return File.OpenRead(tempFile);
+            }
+            return null;
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/CeVIO64Controller.cs
+++ b/src/Speech/Controller/CeVIO64Controller.cs
@@ -262,7 +262,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotSupportedException();
         }
@@ -271,12 +271,12 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             string tempFile = Path.GetTempFileName();
             if (_talker.OutputWaveToFile(text, tempFile))
             {
-                return File.OpenRead(tempFile);
+                return SoundStream.Open(tempFile);
             }
             return null;
         }

--- a/src/Speech/Controller/CeVIO64Controller.cs
+++ b/src/Speech/Controller/CeVIO64Controller.cs
@@ -259,14 +259,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotSupportedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/CeVIO64Controller.cs
+++ b/src/Speech/Controller/CeVIO64Controller.cs
@@ -258,11 +258,6 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             string tempFile = Path.GetTempFileName();

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -263,7 +263,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -272,7 +272,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -260,14 +260,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -259,11 +259,6 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             string tempFile = Path.GetTempFileName();

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -266,7 +266,12 @@ namespace Speech
         /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
-            throw new NotImplementedException();
+            string tempFile = Path.GetTempFileName();
+            if (_talker.OutputWaveToFile(text, tempFile))
+            {
+                return SoundStream.Open(tempFile);
+            }
+            return null;
         }
 
 

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -259,7 +259,7 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             string tempFile = Path.GetTempFileName();
             if (_talker.OutputWaveToFile(text, tempFile))

--- a/src/Speech/Controller/CeVIOAIController.cs
+++ b/src/Speech/Controller/CeVIOAIController.cs
@@ -259,6 +259,24 @@ namespace Speech
             return _talker.Alpha;
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
 
         #region IDisposable Support
         private bool disposedValue = false;

--- a/src/Speech/Controller/CeVIOController.cs
+++ b/src/Speech/Controller/CeVIOController.cs
@@ -258,7 +258,7 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             string tempFile = Path.GetTempFileName();
             if (_talker.OutputWaveToFile(text, tempFile))

--- a/src/Speech/Controller/CeVIOController.cs
+++ b/src/Speech/Controller/CeVIOController.cs
@@ -258,6 +258,29 @@ namespace Speech
             return _talker.Alpha;
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotSupportedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            string tempFile = Path.GetTempFileName();
+            if (_talker.OutputWaveToFile(text, tempFile))
+            {
+                return File.OpenRead(tempFile);
+            }
+            return null;
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/CeVIOController.cs
+++ b/src/Speech/Controller/CeVIOController.cs
@@ -262,7 +262,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotSupportedException();
         }
@@ -271,12 +271,12 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             string tempFile = Path.GetTempFileName();
             if (_talker.OutputWaveToFile(text, tempFile))
             {
-                return File.OpenRead(tempFile);
+                return SoundStream.Open(tempFile);
             }
             return null;
         }

--- a/src/Speech/Controller/CeVIOController.cs
+++ b/src/Speech/Controller/CeVIOController.cs
@@ -259,14 +259,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotSupportedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/CeVIOController.cs
+++ b/src/Speech/Controller/CeVIOController.cs
@@ -258,11 +258,6 @@ namespace Speech
             return _talker.Alpha;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             string tempFile = Path.GetTempFileName();

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.IO;
 
 namespace Speech
 {

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -82,7 +82,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">合成する文字列</param>
         /// <returns>出力された音声の Stream</returns>
-        SoundStream Export(string text);
+        SoundStream ExportToStream(string text);
 
     }
 }

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -78,11 +78,6 @@ namespace Speech
         /// <returns>起動していれば true </returns>
         bool IsActive();
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        SoundStream Export();
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -81,13 +81,13 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        Stream Export();
+        SoundStream Export();
         /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        Stream Export(string text);
+        SoundStream Export(string text);
 
     }
 }

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -78,10 +78,10 @@ namespace Speech
         /// <returns>起動していれば true </returns>
         bool IsActive();
         /// <summary>
-        /// 文字列を音声ファイルとして書き出します
+        /// 指定した文字列を合成した音声を取得します
         /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
+        /// <param name="text">合成する文字列</param>
+        /// <returns>出力された音声の Stream</returns>
         SoundStream Export(string text);
 
     }

--- a/src/Speech/Controller/ISpeechController.cs
+++ b/src/Speech/Controller/ISpeechController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace Speech
 {
@@ -76,6 +77,17 @@ namespace Speech
         /// </summary>
         /// <returns>起動していれば true </returns>
         bool IsActive();
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        Stream Export();
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        Stream Export(string text);
 
     }
 }

--- a/src/Speech/Controller/OtomachiUnaTalkController.cs
+++ b/src/Speech/Controller/OtomachiUnaTalkController.cs
@@ -258,7 +258,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -267,7 +267,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/OtomachiUnaTalkController.cs
+++ b/src/Speech/Controller/OtomachiUnaTalkController.cs
@@ -254,11 +254,6 @@ namespace Speech
             }
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             throw new NotImplementedException();

--- a/src/Speech/Controller/OtomachiUnaTalkController.cs
+++ b/src/Speech/Controller/OtomachiUnaTalkController.cs
@@ -254,7 +254,7 @@ namespace Speech
             }
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/OtomachiUnaTalkController.cs
+++ b/src/Speech/Controller/OtomachiUnaTalkController.cs
@@ -254,6 +254,24 @@ namespace Speech
             }
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/OtomachiUnaTalkController.cs
+++ b/src/Speech/Controller/OtomachiUnaTalkController.cs
@@ -255,14 +255,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -177,14 +177,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -176,7 +176,7 @@ namespace Speech
             return 1f;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             var ms = new MemoryStream();
             synthesizer.SetOutputToWaveStream(ms);

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -183,7 +183,12 @@ namespace Speech
         /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
-            throw new NotImplementedException();
+            var ms = new MemoryStream();
+            synthesizer.SetOutputToWaveStream(ms);
+            synthesizer.Speak(text);
+            synthesizer.SetOutputToDefaultAudioDevice();
+            ms.Position = 0;
+            return new SoundStream(ms);
         }
 
         #region IDisposable Support

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -176,6 +176,24 @@ namespace Speech
             return 1f;
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -180,7 +180,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -189,7 +189,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/SAPI5Controller.cs
+++ b/src/Speech/Controller/SAPI5Controller.cs
@@ -176,11 +176,6 @@ namespace Speech
             return 1f;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             var ms = new MemoryStream();

--- a/src/Speech/Controller/VOICEVOXController.cs
+++ b/src/Speech/Controller/VOICEVOXController.cs
@@ -202,7 +202,7 @@ namespace Speech
         /// <summary>
         /// このメソッドは無効です。発話する文字列を指定してください。
         /// </summary>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotSupportedException("このメソッドは無効です。発話する文字列を指定してください。");
         }
@@ -212,7 +212,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             var content = new StringContent("", Encoding.UTF8, @"application/json");
             var encodeText = Uri.EscapeDataString(text);
@@ -233,7 +233,7 @@ namespace Speech
                 response = client.PostAsync($"{_baseUrl}/synthesis?speaker={talkerNo}", content).GetAwaiter().GetResult();
                 if (response.StatusCode != HttpStatusCode.OK) { return null; }
 
-                return response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+                return new SoundStream(response.Content.ReadAsStreamAsync().GetAwaiter().GetResult());
             }
         }
 

--- a/src/Speech/Controller/VOICEVOXController.cs
+++ b/src/Speech/Controller/VOICEVOXController.cs
@@ -200,11 +200,6 @@ namespace Speech
             return Intonation;
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             var content = new StringContent("", Encoding.UTF8, @"application/json");

--- a/src/Speech/Controller/VOICEVOXController.cs
+++ b/src/Speech/Controller/VOICEVOXController.cs
@@ -102,7 +102,7 @@ namespace Speech
             string tempFile = Path.GetTempFileName();
             try
             {
-                var soundData = Export(text);
+                var soundData = ExportToStream(text);
 
                 using (var fileStream = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
@@ -200,7 +200,7 @@ namespace Speech
             return Intonation;
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             var content = new StringContent("", Encoding.UTF8, @"application/json");
             var encodeText = Uri.EscapeDataString(text);

--- a/src/Speech/Controller/VOICEVOXController.cs
+++ b/src/Speech/Controller/VOICEVOXController.cs
@@ -199,13 +199,6 @@ namespace Speech
         {
             return Intonation;
         }
-        /// <summary>
-        /// このメソッドは無効です。発話する文字列を指定してください。
-        /// </summary>
-        public SoundStream Export()
-        {
-            throw new NotSupportedException("このメソッドは無効です。発話する文字列を指定してください。");
-        }
 
         /// <summary>
         /// 文字列を音声ファイルとして書き出します

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -520,7 +520,6 @@ namespace Speech
             while (true)
             {
                 var dialog = _app.FromZTop();
-                var name = dialog.GetWindowText();
                 if (dialog.TypeFullName == "AI.Talk.Editor.ProgressWindow")
                 {
                     Thread.Sleep(50);

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -297,6 +297,24 @@ namespace Speech
             return Convert.ToSingle(textbox.Text);
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -468,7 +468,7 @@ namespace Speech
             exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             if (CheckPlaying())
             {

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -317,15 +317,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// ファイル分割設定
         /// </summary>
         enum ExportSplitSetting

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -411,12 +411,23 @@ namespace Speech
         {
             void Settings(WindowControl win, bool isSet, ExportSettings exsettings)
             {
+                Functions.WriteTreeIndex(win);
                 var export1File = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 4));
                 var exportSentence = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 5));
                 var exportSplit = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 6));
                 var splitString = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 7, 1));
-                var pauseStart = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 9, 0, 4));
-                var pauseEnd = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 12, 0, 4));
+                WPFTextBox pauseStart = null;
+                WPFTextBox pauseEnd = null;
+                try
+                {
+                    pauseStart = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 9, 0, 4)); ;
+                    pauseEnd = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 12, 0, 4));
+                }
+                catch (WindowIdentifyException e)
+                {
+                    // VOICEROID2 Editor 2.1.1.0 で要素が取得できなくなった
+                    // 取得に失敗した場合はないものとして扱う
+                }
                 var saveWithText = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 9, 1, 2));
                 var showSettings = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 10));
                 if (isSet)
@@ -434,8 +445,8 @@ namespace Speech
                             break;
                     }
                     splitString.EmulateChangeText(exsettings.SplitString);
-                    pauseStart.EmulateChangeText(exsettings.PauseStart.ToString());
-                    pauseEnd.EmulateChangeText(exsettings.PauseEnd.ToString());
+                    pauseStart?.EmulateChangeText(exsettings.PauseStart.ToString());
+                    pauseEnd?.EmulateChangeText(exsettings.PauseEnd.ToString());
                     saveWithText.EmulateCheck(exsettings.SaveWithText);
                     showSettings.EmulateCheck(exsettings.ShowSettings);
                     return;
@@ -453,8 +464,14 @@ namespace Speech
                     exsettings.SplitSetting = ExportSplitSetting.Delimiter;
                 }
                 exsettings.SplitString = splitString.Text;
-                exsettings.PauseStart = long.Parse(pauseStart.Text);
-                exsettings.PauseEnd = long.Parse(pauseEnd.Text);
+                if (pauseStart != null)
+                {
+                    exsettings.PauseStart = long.Parse(pauseStart.Text);
+                }
+                if (pauseEnd != null)
+                {
+                    exsettings.PauseEnd = long.Parse(pauseEnd.Text);
+                }
                 exsettings.SaveWithText = saveWithText.IsChecked.GetValueOrDefault(false);
                 exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
             }

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -1,6 +1,7 @@
 ﻿using Codeer.Friendly;
 using Codeer.Friendly.Windows;
 using Codeer.Friendly.Windows.Grasp;
+using Codeer.Friendly.Windows.NativeStandardControls;
 using RM.Friendly.WPFStandardControls;
 using System;
 using System.Collections.Generic;
@@ -107,6 +108,14 @@ namespace Speech
             }
         }
 
+        private bool CheckPlaying()
+        {
+            WPFButtonBase playButton = new WPFButtonBase(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 3, 0));
+            var d = playButton.LogicalTree();
+            System.Windows.Visibility v = (System.Windows.Visibility)(d[2])["Visibility"]().Core;
+            return !System.Windows.Visibility.Visible.Equals(v);
+        }
+
         private void StopSpeech()
         {
             _timer.Stop();
@@ -179,12 +188,11 @@ namespace Speech
         /// <param name="text">再生する文字列</param>
         public void Play(string text)
         {
-            SetText(text);
+            SetTextAndPlay(text);
         }
-        internal virtual void SetText(string text)
+        internal virtual void SetTextAndPlay(string text)
         {
-            text = text.Trim() == "" ? "." : text;
-            string t = _libraryName + _promptString + text;
+            string t = AssembleText(text);
             if (_queue.Count == 0)
             {
                 WPFTextBox textbox = new WPFTextBox(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 2));
@@ -195,6 +203,17 @@ namespace Speech
             {
                 _queue.Enqueue(t);
             }
+        }
+        internal virtual void SetText(string text)
+        {
+            string t = AssembleText(text);
+            WPFTextBox textbox = new WPFTextBox(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 2));
+            textbox.EmulateChangeText(t);
+        }
+        internal virtual string AssembleText(string text)
+        {
+            text = text.Trim() == "" ? "." : text;
+            return _libraryName + _promptString + text;
         }
 
         /// <summary>
@@ -305,6 +324,93 @@ namespace Speech
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// ファイル分割設定
+        /// </summary>
+        enum ExportSplitSetting
+        {
+            /// <summary>
+            /// 一つのファイルに書き出す
+            /// </summary>
+            OneFile,
+            /// <summary>
+            /// 1文毎に区切って複数のファイルに書き出す
+            /// </summary>
+            Sentence,
+            /// <summary>
+            /// 指定された文字列で区切って複数のファイルに書き出す
+            /// </summary>
+            Delimiter
+        }
+
+        /// <summary>
+        /// 音声保存設定を保持するクラス
+        /// </summary>
+        class ExportSettings
+        {
+            /// <summary>
+            /// ファイル分割設定
+            /// </summary>
+            public ExportSplitSetting SplitSetting { get; set; } = ExportSplitSetting.OneFile;
+            /// <summary>
+            /// 区切り文字列
+            /// </summary>
+            public string SplitString { get; set; } = "/";
+            /// <summary>
+            /// 開始ポーズ(ミリ秒)
+            /// </summary>
+            public long PauseStart { get; set; } = 0;
+            /// <summary>
+            /// 終了ポーズ(ミリ秒)
+            /// </summary>
+            public long PauseEnd { get; set; } = 800;
+            /// <summary>
+            /// テキストファイルを音声ファイルと一緒に保存する
+            /// </summary>
+            public bool SaveWithText { get; set; } = false;
+            /// <summary>
+            /// 音声保存時に毎回設定を表示する
+            /// </summary>
+            public bool ShowSettings { get; set; } = true;
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+
+                sb.Append(nameof(SplitSetting));
+                sb.Append(":");
+                sb.Append(SplitSetting);
+                sb.Append(", ");
+
+                sb.Append(nameof(SplitString));
+                sb.Append(":");
+                sb.Append(SplitString);
+                sb.Append(", ");
+
+                sb.Append(nameof(PauseStart));
+                sb.Append(":");
+                sb.Append(PauseStart);
+                sb.Append(", ");
+
+                sb.Append(nameof(PauseEnd));
+                sb.Append(":");
+                sb.Append(PauseEnd);
+                sb.Append(", ");
+
+                sb.Append(nameof(SaveWithText));
+                sb.Append(":");
+                sb.Append(SaveWithText);
+                sb.Append(", ");
+
+                sb.Append(nameof(ShowSettings));
+                sb.Append(":");
+                sb.Append(ShowSettings);
+                sb.Append(", ");
+
+                return sb.ToString();
+            }
+        }
+
         /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
@@ -312,7 +418,125 @@ namespace Speech
         /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
-            throw new NotImplementedException();
+            void Settings(WindowControl win, bool isSet, ExportSettings exsettings)
+            {
+                var export1File = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 4));
+                var exportSentence = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 5));
+                var exportSplit = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 6));
+                var splitString = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 7, 1));
+                var pauseStart = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 9, 0, 4));
+                var pauseEnd = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 12, 0, 4));
+                var saveWithText = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 9, 1, 2));
+                var showSettings = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 10));
+                if (isSet)
+                {
+                    switch (exsettings.SplitSetting)
+                    {
+                        case ExportSplitSetting.OneFile:
+                            export1File.EmulateCheck(true);
+                            break;
+                        case ExportSplitSetting.Sentence:
+                            exportSentence.EmulateCheck(true);
+                            break;
+                        case ExportSplitSetting.Delimiter:
+                            exportSplit.EmulateCheck(true);
+                            break;
+                    }
+                    splitString.EmulateChangeText(exsettings.SplitString);
+                    pauseStart.EmulateChangeText(exsettings.PauseStart.ToString());
+                    pauseEnd.EmulateChangeText(exsettings.PauseEnd.ToString());
+                    saveWithText.EmulateCheck(exsettings.SaveWithText);
+                    showSettings.EmulateCheck(exsettings.ShowSettings);
+                    return;
+                }
+                if (export1File.IsChecked.GetValueOrDefault(true))
+                {
+                    exsettings.SplitSetting = ExportSplitSetting.OneFile;
+                }
+                if (exportSentence.IsChecked.GetValueOrDefault(false))
+                {
+                    exsettings.SplitSetting = ExportSplitSetting.Sentence;
+                }
+                if (exportSplit.IsChecked.GetValueOrDefault(false))
+                {
+                    exsettings.SplitSetting = ExportSplitSetting.Delimiter;
+                }
+                exsettings.SplitString = splitString.Text;
+                exsettings.PauseStart = long.Parse(pauseStart.Text);
+                exsettings.PauseEnd = long.Parse(pauseEnd.Text);
+                exsettings.SaveWithText = saveWithText.IsChecked.GetValueOrDefault(false);
+                exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
+            }
+            if (CheckPlaying())
+            {
+                // 再生中だと音声保存メニューを開けない
+                throw new InvalidOperationException("再生中のため処理できません");
+            }
+
+            var top = _app.FromZTop();
+            if (top.TypeFullName != "AI.Talk.Editor.MainWindow")
+            {
+                // TODO: 復帰処理を書く
+                throw new InvalidOperationException("何らかのウィンドウが開かれているため処理できません");
+            }
+            SetText(text);
+
+            var saveSoundMenu = new WPFMenuItem(_root.IdentifyFromLogicalTreeIndex(0, 3, 0, 7));
+            var saveWaveAsync = new Async();
+            saveSoundMenu.EmulateClick(saveWaveAsync);
+
+            var saveWaveWindow = _root.WaitForNextModal();
+            SaveFileDialog saveFileDialog = null;
+            Async okAsync = null;
+            if (saveWaveWindow.TypeFullName == "AI.Talk.Editor.SaveWaveWindow")
+            {
+                ExportSettings settings = new ExportSettings();
+                Settings(saveWaveWindow, false, settings);
+                settings.SplitSetting = ExportSplitSetting.OneFile;
+                settings.SaveWithText = false;
+                Settings(saveWaveWindow, true, settings);
+
+                var okButton = new WPFButtonBase(saveWaveWindow.IdentifyFromLogicalTreeIndex(0, 1, 0));
+                okAsync = new Async();
+                okButton.EmulateClick(okAsync);
+
+                saveFileDialog = new SaveFileDialog(saveWaveWindow.WaitForNextModal());
+            }
+            else
+            {
+                // 設定の「音声保存時に毎回設定を表示する」の場合は設定画面が出ない
+                // 設定を変更できないのであとの処理でエラーになる可能性がある
+                Console.Error.WriteLine("「音声保存時に毎回設定を表示する」にチェックが入っていないためエラーが発生する可能性があります");
+                saveFileDialog = new SaveFileDialog(saveWaveWindow);
+            }
+
+            var filePath = Path.Combine(Path.GetTempPath(), $"{this.GetType().Name}_{(uint)text.GetHashCode()}.wav");
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+            saveFileDialog.Save(filePath);
+
+            while (true)
+            {
+                var dialog = _app.FromZTop();
+                var name = dialog.GetWindowText();
+                if (dialog.TypeFullName == "AI.Talk.Editor.ProgressWindow")
+                {
+                    Thread.Sleep(50);
+                    continue;
+                }
+                var button = dialog.GetFromWindowClass("Button");
+                foreach (var b in button)
+                {
+                    var nb = new NativeButton(b);
+                    nb.EmulateClick();
+                }
+                break;
+            }
+            okAsync?.WaitForCompletion();
+            saveWaveAsync.WaitForCompletion();
+            return SoundStream.Open(filePath);
         }
 
         #region IDisposable Support

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -301,7 +301,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -310,7 +310,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -319,7 +319,7 @@ namespace Speech
         /// <summary>
         /// ファイル分割設定
         /// </summary>
-        enum ExportSplitSetting
+        public enum ExportSplitSetting
         {
             /// <summary>
             /// 一つのファイルに書き出す
@@ -338,7 +338,7 @@ namespace Speech
         /// <summary>
         /// 音声保存設定を保持するクラス
         /// </summary>
-        class ExportSettings
+        public class ExportSettings
         {
             /// <summary>
             /// ファイル分割設定
@@ -402,6 +402,72 @@ namespace Speech
             }
         }
 
+        public static void ExportSetting(WindowControl win, bool isSet, ExportSettings exsettings)
+        {
+            var export1File = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 4));
+            var exportSentence = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 5));
+            var exportSplit = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 6));
+            var splitString = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 7, 1));
+            WPFTextBox pauseStart = null;
+            WPFTextBox pauseEnd = null;
+            try
+            {
+                pauseStart = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 9, 0, 4)); ;
+                pauseEnd = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 12, 0, 4));
+            }
+            catch (WindowIdentifyException e)
+            {
+                // VOICEROID2 Editor 2.1.1.0 で要素が取得できなくなった
+                // 取得に失敗した場合はないものとして扱う
+            }
+            var saveWithText = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 9, 1, 2));
+            var showSettings = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 10));
+            if (isSet)
+            {
+                switch (exsettings.SplitSetting)
+                {
+                    case ExportSplitSetting.OneFile:
+                        export1File.EmulateCheck(true);
+                        break;
+                    case ExportSplitSetting.Sentence:
+                        exportSentence.EmulateCheck(true);
+                        break;
+                    case ExportSplitSetting.Delimiter:
+                        exportSplit.EmulateCheck(true);
+                        break;
+                }
+                splitString.EmulateChangeText(exsettings.SplitString);
+                pauseStart?.EmulateChangeText(exsettings.PauseStart.ToString());
+                pauseEnd?.EmulateChangeText(exsettings.PauseEnd.ToString());
+                saveWithText.EmulateCheck(exsettings.SaveWithText);
+                showSettings.EmulateCheck(exsettings.ShowSettings);
+                return;
+            }
+            if (export1File.IsChecked.GetValueOrDefault(true))
+            {
+                exsettings.SplitSetting = ExportSplitSetting.OneFile;
+            }
+            if (exportSentence.IsChecked.GetValueOrDefault(false))
+            {
+                exsettings.SplitSetting = ExportSplitSetting.Sentence;
+            }
+            if (exportSplit.IsChecked.GetValueOrDefault(false))
+            {
+                exsettings.SplitSetting = ExportSplitSetting.Delimiter;
+            }
+            exsettings.SplitString = splitString.Text;
+            if (pauseStart != null)
+            {
+                exsettings.PauseStart = long.Parse(pauseStart.Text);
+            }
+            if (pauseEnd != null)
+            {
+                exsettings.PauseEnd = long.Parse(pauseEnd.Text);
+            }
+            exsettings.SaveWithText = saveWithText.IsChecked.GetValueOrDefault(false);
+            exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
+        }
+
         /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
@@ -409,72 +475,6 @@ namespace Speech
         /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
-            void Settings(WindowControl win, bool isSet, ExportSettings exsettings)
-            {
-                Functions.WriteTreeIndex(win);
-                var export1File = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 4));
-                var exportSentence = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 5));
-                var exportSplit = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 6));
-                var splitString = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 6, 1, 3, 7, 1));
-                WPFTextBox pauseStart = null;
-                WPFTextBox pauseEnd = null;
-                try
-                {
-                    pauseStart = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 9, 0, 4)); ;
-                    pauseEnd = new WPFTextBox(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 7, 1, 12, 0, 4));
-                }
-                catch (WindowIdentifyException e)
-                {
-                    // VOICEROID2 Editor 2.1.1.0 で要素が取得できなくなった
-                    // 取得に失敗した場合はないものとして扱う
-                }
-                var saveWithText = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 9, 1, 2));
-                var showSettings = new WPFToggleButton(win.IdentifyFromLogicalTreeIndex(0, 0, 0, 10));
-                if (isSet)
-                {
-                    switch (exsettings.SplitSetting)
-                    {
-                        case ExportSplitSetting.OneFile:
-                            export1File.EmulateCheck(true);
-                            break;
-                        case ExportSplitSetting.Sentence:
-                            exportSentence.EmulateCheck(true);
-                            break;
-                        case ExportSplitSetting.Delimiter:
-                            exportSplit.EmulateCheck(true);
-                            break;
-                    }
-                    splitString.EmulateChangeText(exsettings.SplitString);
-                    pauseStart?.EmulateChangeText(exsettings.PauseStart.ToString());
-                    pauseEnd?.EmulateChangeText(exsettings.PauseEnd.ToString());
-                    saveWithText.EmulateCheck(exsettings.SaveWithText);
-                    showSettings.EmulateCheck(exsettings.ShowSettings);
-                    return;
-                }
-                if (export1File.IsChecked.GetValueOrDefault(true))
-                {
-                    exsettings.SplitSetting = ExportSplitSetting.OneFile;
-                }
-                if (exportSentence.IsChecked.GetValueOrDefault(false))
-                {
-                    exsettings.SplitSetting = ExportSplitSetting.Sentence;
-                }
-                if (exportSplit.IsChecked.GetValueOrDefault(false))
-                {
-                    exsettings.SplitSetting = ExportSplitSetting.Delimiter;
-                }
-                exsettings.SplitString = splitString.Text;
-                if (pauseStart != null)
-                {
-                    exsettings.PauseStart = long.Parse(pauseStart.Text);
-                }
-                if (pauseEnd != null)
-                {
-                    exsettings.PauseEnd = long.Parse(pauseEnd.Text);
-                }
-                exsettings.SaveWithText = saveWithText.IsChecked.GetValueOrDefault(false);
-                exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
-            }
             if (CheckPlaying())
             {
                 // 再生中だと音声保存メニューを開けない
@@ -499,10 +499,10 @@ namespace Speech
             if (saveWaveWindow.TypeFullName == "AI.Talk.Editor.SaveWaveWindow")
             {
                 ExportSettings settings = new ExportSettings();
-                Settings(saveWaveWindow, false, settings);
+                ExportSetting(saveWaveWindow, false, settings);
                 settings.SplitSetting = ExportSplitSetting.OneFile;
                 settings.SaveWithText = false;
-                Settings(saveWaveWindow, true, settings);
+                ExportSetting(saveWaveWindow, true, settings);
 
                 var okButton = new WPFButtonBase(saveWaveWindow.IdentifyFromLogicalTreeIndex(0, 1, 0));
                 okAsync = new Async();

--- a/src/Speech/Controller/Voiceroid2Controller.cs
+++ b/src/Speech/Controller/Voiceroid2Controller.cs
@@ -468,11 +468,6 @@ namespace Speech
             exsettings.ShowSettings = showSettings.IsChecked.GetValueOrDefault(true);
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             if (CheckPlaying())

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -314,7 +314,7 @@ namespace Speech
             return Convert.ToSingle(textbox.Text);
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             if (CheckPlaying())
             {

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -299,7 +299,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -308,7 +308,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -296,14 +296,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -1,6 +1,7 @@
 ﻿using Codeer.Friendly;
 using Codeer.Friendly.Windows;
 using Codeer.Friendly.Windows.Grasp;
+using Codeer.Friendly.Windows.NativeStandardControls;
 using RM.Friendly.WPFStandardControls;
 using System;
 using System.Collections.Generic;
@@ -104,6 +105,14 @@ namespace Speech
             }
         }
 
+        private bool CheckPlaying()
+        {
+            WPFButtonBase playButton = new WPFButtonBase(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 3, 0));
+            var d = playButton.LogicalTree();
+            System.Windows.Visibility v = (System.Windows.Visibility)(d[2])["Visibility"]().Core;
+            return !System.Windows.Visibility.Visible.Equals(v);
+        }
+
         private void StopSpeech()
         {
             _timer.Stop();
@@ -177,12 +186,11 @@ namespace Speech
         /// <param name="text">再生する文字列</param>
         public void Play(string text)
         {
-            SetText(text);
+            SetTextAndPlay(text);
         }
-        internal virtual void SetText(string text)
+        internal virtual void SetTextAndPlay(string text)
         {
-            text = text.Trim() == "" ? "." : text;
-            string t = _libraryName + _promptString + text;
+            string t = AssembleText(text);
             if (_queue.Count == 0)
             {
                 WPFTextBox textbox = new WPFTextBox(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 2));
@@ -193,6 +201,17 @@ namespace Speech
             {
                 _queue.Enqueue(t);
             }
+        }
+        internal virtual void SetText(string text)
+        {
+            string t = AssembleText(text);
+            WPFTextBox textbox = new WPFTextBox(_root.IdentifyFromLogicalTreeIndex(0, 4, 3, 5, 3, 0, 2));
+            textbox.EmulateChangeText(t);
+        }
+        internal virtual string AssembleText(string text)
+        {
+            text = text.Trim() == "" ? "." : text;
+            return _libraryName + _promptString + text;
         }
 
         /// <summary>
@@ -302,7 +321,75 @@ namespace Speech
         /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
-            throw new NotImplementedException();
+            if (CheckPlaying())
+            {
+                // 再生中だと音声保存メニューを開けない
+                throw new InvalidOperationException("再生中のため処理できません");
+            }
+
+            var top = _app.FromZTop();
+            if (top.TypeFullName != "AI.Talk.Editor.MainWindow")
+            {
+                // TODO: 復帰処理を書く
+                throw new InvalidOperationException("何らかのウィンドウが開かれているため処理できません");
+            }
+            SetText(text);
+
+            var saveSoundMenu = new WPFMenuItem(_root.IdentifyFromLogicalTreeIndex(0, 3, 0, 7));
+            var saveWaveAsync = new Async();
+            saveSoundMenu.EmulateClick(saveWaveAsync);
+
+            var saveWaveWindow = _root.WaitForNextModal();
+            SaveFileDialog saveFileDialog = null;
+            Async okAsync = null;
+            if (saveWaveWindow.TypeFullName == "AI.Talk.Editor.SaveWaveWindow")
+            {
+                Voiceroid2Controller.ExportSettings settings = new Voiceroid2Controller.ExportSettings();
+                Voiceroid2Controller.ExportSetting(saveWaveWindow, false, settings);
+                settings.SplitSetting = Voiceroid2Controller.ExportSplitSetting.OneFile;
+                settings.SaveWithText = false;
+                Voiceroid2Controller.ExportSetting(saveWaveWindow, true, settings);
+
+                var okButton = new WPFButtonBase(saveWaveWindow.IdentifyFromLogicalTreeIndex(0, 1, 0));
+                okAsync = new Async();
+                okButton.EmulateClick(okAsync);
+
+                saveFileDialog = new SaveFileDialog(saveWaveWindow.WaitForNextModal());
+            }
+            else
+            {
+                // 設定の「音声保存時に毎回設定を表示する」の場合は設定画面が出ない
+                // 設定を変更できないのであとの処理でエラーになる可能性がある
+                Console.Error.WriteLine("「音声保存時に毎回設定を表示する」にチェックが入っていないためエラーが発生する可能性があります");
+                saveFileDialog = new SaveFileDialog(saveWaveWindow);
+            }
+
+            var filePath = Path.Combine(Path.GetTempPath(), $"{this.GetType().Name}_{(uint)text.GetHashCode()}.wav");
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+            saveFileDialog.Save(filePath);
+
+            while (true)
+            {
+                var dialog = _app.FromZTop();
+                if (dialog.TypeFullName == "AI.Talk.Editor.ProgressWindow")
+                {
+                    Thread.Sleep(50);
+                    continue;
+                }
+                var button = dialog.GetFromWindowClass("Button");
+                foreach (var b in button)
+                {
+                    var nb = new NativeButton(b);
+                    nb.EmulateClick();
+                }
+                break;
+            }
+            okAsync?.WaitForCompletion();
+            saveWaveAsync.WaitForCompletion();
+            return SoundStream.Open(filePath);
         }
 
         #region IDisposable Support

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -314,11 +314,6 @@ namespace Speech
             return Convert.ToSingle(textbox.Text);
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             if (CheckPlaying())

--- a/src/Speech/Controller/Voiceroid64Controller.cs
+++ b/src/Speech/Controller/Voiceroid64Controller.cs
@@ -295,6 +295,24 @@ namespace Speech
             return Convert.ToSingle(textbox.Text);
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -268,14 +268,6 @@ namespace Speech
         }
 
         /// <summary>
-        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
-        /// </summary>
-        /// <returns>出力された音声</returns>
-        public SoundStream Export()
-        {
-            throw new NotImplementedException();
-        }
-        /// <summary>
         /// 文字列を音声ファイルとして書き出します
         /// </summary>
         /// <param name="text">再生する文字列</param>

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Threading;

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -267,11 +267,6 @@ namespace Speech
             }
         }
 
-        /// <summary>
-        /// 文字列を音声ファイルとして書き出します
-        /// </summary>
-        /// <param name="text">再生する文字列</param>
-        /// <returns>出力された音声</returns>
         public SoundStream Export(string text)
         {
             SetText(text);

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -266,7 +266,7 @@ namespace Speech
         /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
         /// </summary>
         /// <returns>出力された音声</returns>
-        public Stream Export()
+        public SoundStream Export()
         {
             throw new NotImplementedException();
         }
@@ -275,7 +275,7 @@ namespace Speech
         /// </summary>
         /// <param name="text">再生する文字列</param>
         /// <returns>出力された音声</returns>
-        public Stream Export(string text)
+        public SoundStream Export(string text)
         {
             throw new NotImplementedException();
         }

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -262,6 +262,24 @@ namespace Speech
             }
         }
 
+        /// <summary>
+        /// 音声合成エンジンに設定済みのテキストを音声ファイルとして書き出します
+        /// </summary>
+        /// <returns>出力された音声</returns>
+        public Stream Export()
+        {
+            throw new NotImplementedException();
+        }
+        /// <summary>
+        /// 文字列を音声ファイルとして書き出します
+        /// </summary>
+        /// <param name="text">再生する文字列</param>
+        /// <returns>出力された音声</returns>
+        public Stream Export(string text)
+        {
+            throw new NotImplementedException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Speech/Controller/VoiceroidPlusController.cs
+++ b/src/Speech/Controller/VoiceroidPlusController.cs
@@ -267,7 +267,7 @@ namespace Speech
             }
         }
 
-        public SoundStream Export(string text)
+        public SoundStream ExportToStream(string text)
         {
             SetText(text);
 

--- a/src/Speech/SaveFileDialog.cs
+++ b/src/Speech/SaveFileDialog.cs
@@ -1,0 +1,55 @@
+﻿using Codeer.Friendly.Windows.Grasp;
+using Codeer.Friendly.Windows.NativeStandardControls;
+
+namespace Speech
+{
+    /// <summary>
+    /// 名前を付けて保存ダイアログをラップします
+    /// </summary>
+    internal class SaveFileDialog
+    {
+        /// <summary>
+        /// このクラスでラップしているWindowControlインスタンスを取得します
+        /// </summary>
+        public WindowControl Window { get; private set; }
+
+        /// <summary>
+        /// ファイル保存ダイアログを指定して初期化します
+        /// </summary>
+        /// <param name="dialog">名前を付けて保存ダイアログのインスタンス</param>
+        public SaveFileDialog(WindowControl dialog)
+        {
+            Window = dialog;
+        }
+
+        /// <summary>
+        /// ダイアログのファイル名を設定します
+        /// </summary>
+        /// <param name="path">保存先パス</param>
+        public void SetFilePath(string path)
+        {
+            var combobox = Window.GetFromWindowClass("ComboBox");
+            var textbox = new NativeEdit(combobox[combobox.Length - 1]); // 一番最後に取得できたものをファイルパス指定とする
+            textbox.EmulateChangeText(path);
+        }
+
+        /// <summary>
+        /// 保存ボタンを押します
+        /// </summary>
+        public void Save()
+        {
+            var save = new NativeButton(Window.IdentifyFromWindowText("保存(&S)")); // TODO: 日本語環境でしか動かない
+            save.EmulateClick();
+        }
+
+        /// <summary>
+        /// ファイル名を設定して保存ボタンを押します
+        /// </summary>
+        /// <param name="path">保存先パス</param>
+        public void Save(string path)
+        {
+            SetFilePath(path);
+            Save();
+        }
+    }
+}

--- a/src/Speech/SoundStream.cs
+++ b/src/Speech/SoundStream.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace Speech
+{
+    public class SoundStream : Stream, IDisposable
+    {
+        /// <summary>
+        /// ファイルパスを指定してインスタンスを初期化します
+        /// </summary>
+        /// <param name="path">ファイルパス</param>
+        /// <param name="deleteOnClose">Close時にファイルを削除するか指定します</param>
+        public static SoundStream Open(string path, bool deleteOnClose = true)
+        {
+            var fo = FileOptions.SequentialScan;
+            if(deleteOnClose)
+            {
+                fo |= FileOptions.DeleteOnClose;
+            }
+            var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None, 524288, fo);
+            return new SoundStream(fs);
+        }
+
+        /// <summary>
+        /// 元となるStreamを指定してインスタンスを初期化します
+        /// </summary>
+        /// <param name="stream">元となるStreamインスタンス</param>
+        public SoundStream(Stream stream)
+        {
+            this.BaseStream = stream;
+        }
+        public Stream BaseStream { get; private set; }
+
+        public override bool CanRead => BaseStream.CanRead;
+
+        public override bool CanSeek => BaseStream.CanSeek;
+
+        public override bool CanWrite => BaseStream.CanWrite;
+
+        public override long Length => BaseStream.Length;
+
+        public override long Position { get => BaseStream.Position; set => BaseStream.Position = value; }
+
+        public override void Flush()
+        {
+            BaseStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return BaseStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return BaseStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            BaseStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            BaseStream.Write(buffer, offset, count);
+        }
+
+        public new void Dispose()
+        {
+            BaseStream?.Dispose();
+        }
+    }
+}

--- a/src/Speech/SoundStream.cs
+++ b/src/Speech/SoundStream.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
 
 namespace Speech

--- a/src/Speech/Speech.csproj
+++ b/src/Speech/Speech.csproj
@@ -116,6 +116,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SaveFileDialog.cs" />
     <Compile Include="Controller\AIVOICEController.cs" />
     <Compile Include="Controller\CeVIOAIController.cs" />
     <Compile Include="Controller\CeVIOAIEnumerator.cs" />

--- a/src/Speech/Speech.csproj
+++ b/src/Speech/Speech.csproj
@@ -56,37 +56,49 @@
     <Reference Include="Codeer.Friendly.Dynamic, Version=2.6.1.0, Culture=neutral, PublicKeyToken=376bc779077733e8, processorArchitecture=MSIL">
       <HintPath>..\packages\Codeer.Friendly.2.6.1\lib\net40\Codeer.Friendly.Dynamic.dll</HintPath>
     </Reference>
-    <Reference Include="Codeer.Friendly.Windows, Version=2.15.0.0, Culture=neutral, PublicKeyToken=532f270f1da385b3, processorArchitecture=MSIL">
-      <HintPath>..\packages\Codeer.Friendly.Windows.2.15.0\lib\net20\Codeer.Friendly.Windows.dll</HintPath>
+    <Reference Include="Codeer.Friendly.Windows, Version=2.16.0.0, Culture=neutral, PublicKeyToken=532f270f1da385b3, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.2.16.0\lib\net20\Codeer.Friendly.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="Codeer.Friendly.Windows.Grasp.2.0, Version=2.12.0.0, Culture=neutral, PublicKeyToken=92809a28945fb91d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Codeer.Friendly.Windows.Grasp.2.12.0\lib\net35\Codeer.Friendly.Windows.Grasp.2.0.dll</HintPath>
+    <Reference Include="Codeer.Friendly.Windows.Grasp.2.0, Version=2.14.1.0, Culture=neutral, PublicKeyToken=92809a28945fb91d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.Grasp.2.14.1\lib\net35\Codeer.Friendly.Windows.Grasp.2.0.dll</HintPath>
     </Reference>
-    <Reference Include="Codeer.Friendly.Windows.Grasp.3.5, Version=2.12.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Codeer.Friendly.Windows.Grasp.2.12.0\lib\net35\Codeer.Friendly.Windows.Grasp.3.5.dll</HintPath>
+    <Reference Include="Codeer.Friendly.Windows.Grasp.3.5, Version=2.14.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.Grasp.2.14.1\lib\net35\Codeer.Friendly.Windows.Grasp.3.5.dll</HintPath>
     </Reference>
-    <Reference Include="Codeer.TestAssistant.GeneratorToolKit, Version=3.10.0.0, Culture=neutral, PublicKeyToken=f7af39ab9bcf13fe, processorArchitecture=MSIL">
-      <HintPath>..\packages\Codeer.TestAssistant.GeneratorToolKit.3.10.0\lib\net20\Codeer.TestAssistant.GeneratorToolKit.dll</HintPath>
+    <Reference Include="Codeer.Friendly.Windows.NativeStandardControls, Version=2.16.9.0, Culture=neutral, PublicKeyToken=90759bf0c8b8639e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.NativeStandardControls.2.16.9\lib\net40\Codeer.Friendly.Windows.NativeStandardControls.dll</HintPath>
+    </Reference>
+    <Reference Include="Codeer.Friendly.Windows.NativeStandardControls.4.0, Version=2.16.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.NativeStandardControls.2.16.9\lib\net40\Codeer.Friendly.Windows.NativeStandardControls.4.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Codeer.Friendly.Windows.NativeStandardControls.Generator, Version=2.16.9.0, Culture=neutral, PublicKeyToken=eea982eb65b72dea, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.Friendly.Windows.NativeStandardControls.2.16.9\lib\net40\Codeer.Friendly.Windows.NativeStandardControls.Generator.dll</HintPath>
+    </Reference>
+    <Reference Include="Codeer.TestAssistant.GeneratorToolKit, Version=3.13.0.0, Culture=neutral, PublicKeyToken=f7af39ab9bcf13fe, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.TestAssistant.GeneratorToolKit.3.13.0\lib\net40\Codeer.TestAssistant.GeneratorToolKit.dll</HintPath>
+    </Reference>
+    <Reference Include="Codeer.TestAssistant.GeneratorToolKit.4.0, Version=3.13.0.0, Culture=neutral, PublicKeyToken=f1ee4e89052c526f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Codeer.TestAssistant.GeneratorToolKit.3.13.0\lib\net40\Codeer.TestAssistant.GeneratorToolKit.4.0.dll</HintPath>
     </Reference>
     <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="RM.Friendly.WPFStandardControls.3.0, Version=1.46.1.0, Culture=neutral, PublicKeyToken=1b8f25b96765ebb0, processorArchitecture=MSIL">
-      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.46.1\lib\net40\RM.Friendly.WPFStandardControls.3.0.dll</HintPath>
+    <Reference Include="RM.Friendly.WPFStandardControls.3.0, Version=1.59.0.0, Culture=neutral, PublicKeyToken=1b8f25b96765ebb0, processorArchitecture=MSIL">
+      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.59.0\lib\net40\RM.Friendly.WPFStandardControls.3.0.dll</HintPath>
     </Reference>
-    <Reference Include="RM.Friendly.WPFStandardControls.3.0.Generator, Version=1.46.1.0, Culture=neutral, PublicKeyToken=41822cddf2e8cce7, processorArchitecture=MSIL">
-      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.46.1\lib\net40\RM.Friendly.WPFStandardControls.3.0.Generator.dll</HintPath>
+    <Reference Include="RM.Friendly.WPFStandardControls.3.0.Generator, Version=1.59.0.0, Culture=neutral, PublicKeyToken=41822cddf2e8cce7, processorArchitecture=MSIL">
+      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.59.0\lib\net40\RM.Friendly.WPFStandardControls.3.0.Generator.dll</HintPath>
     </Reference>
-    <Reference Include="RM.Friendly.WPFStandardControls.3.5, Version=1.46.1.0, Culture=neutral, PublicKeyToken=133fc95b5bce0b86, processorArchitecture=MSIL">
-      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.46.1\lib\net40\RM.Friendly.WPFStandardControls.3.5.dll</HintPath>
+    <Reference Include="RM.Friendly.WPFStandardControls.3.5, Version=1.59.0.0, Culture=neutral, PublicKeyToken=133fc95b5bce0b86, processorArchitecture=MSIL">
+      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.59.0\lib\net40\RM.Friendly.WPFStandardControls.3.5.dll</HintPath>
     </Reference>
-    <Reference Include="RM.Friendly.WPFStandardControls.4.0, Version=1.46.1.0, Culture=neutral, PublicKeyToken=804da7e4293a9f15, processorArchitecture=MSIL">
-      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.46.1\lib\net40\RM.Friendly.WPFStandardControls.4.0.dll</HintPath>
+    <Reference Include="RM.Friendly.WPFStandardControls.4.0, Version=1.59.0.0, Culture=neutral, PublicKeyToken=804da7e4293a9f15, processorArchitecture=MSIL">
+      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.59.0\lib\net40\RM.Friendly.WPFStandardControls.4.0.dll</HintPath>
     </Reference>
-    <Reference Include="RM.Friendly.WPFStandardControls.4.0.Generator, Version=1.46.1.0, Culture=neutral, PublicKeyToken=12a0c2a29e956d84, processorArchitecture=MSIL">
-      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.46.1\lib\net40\RM.Friendly.WPFStandardControls.4.0.Generator.dll</HintPath>
+    <Reference Include="RM.Friendly.WPFStandardControls.4.0.Generator, Version=1.59.0.0, Culture=neutral, PublicKeyToken=12a0c2a29e956d84, processorArchitecture=MSIL">
+      <HintPath>..\packages\RM.Friendly.WPFStandardControls.1.59.0\lib\net40\RM.Friendly.WPFStandardControls.4.0.Generator.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Speech/Speech.csproj
+++ b/src/Speech/Speech.csproj
@@ -140,6 +140,7 @@
     <Compile Include="SoundRecorder.cs" />
     <Compile Include="Controller\SAPI5Enumerator.cs" />
     <Compile Include="SoundPlayer.cs" />
+    <Compile Include="SoundStream.cs" />
     <Compile Include="SpeechEngineInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Controller\SAPI5Controller.cs" />

--- a/src/Speech/app.config
+++ b/src/Speech/app.config
@@ -8,11 +8,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Codeer.Friendly.Windows" publicKeyToken="532f270f1da385b3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.15.0.0" newVersion="2.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.16.0.0" newVersion="2.16.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Codeer.Friendly.Dynamic" publicKeyToken="376bc779077733e8" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.6.1.0" newVersion="2.6.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Codeer.TestAssistant.GeneratorToolKit" publicKeyToken="f7af39ab9bcf13fe" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.13.0.0" newVersion="3.13.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Codeer.Friendly.Windows.Grasp.2.0" publicKeyToken="92809a28945fb91d" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.14.1.0" newVersion="2.14.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Speech/packages.config
+++ b/src/Speech/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Codeer.Friendly" version="2.6.1" targetFramework="net452" />
-  <package id="Codeer.Friendly.Windows" version="2.15.0" targetFramework="net452" />
-  <package id="Codeer.Friendly.Windows.Grasp" version="2.12.0" targetFramework="net452" />
-  <package id="Codeer.TestAssistant.GeneratorToolKit" version="3.10.0" targetFramework="net452" />
+  <package id="Codeer.Friendly.Windows" version="2.16.0" targetFramework="net452" />
+  <package id="Codeer.Friendly.Windows.Grasp" version="2.14.1" targetFramework="net452" />
+  <package id="Codeer.Friendly.Windows.NativeStandardControls" version="2.16.9" targetFramework="net452" />
+  <package id="Codeer.TestAssistant.GeneratorToolKit" version="3.13.0" targetFramework="net452" />
   <package id="NAudio" version="1.8.4" targetFramework="net452" />
-  <package id="RM.Friendly.WPFStandardControls" version="1.46.1" targetFramework="net452" />
+  <package id="RM.Friendly.WPFStandardControls" version="1.59.0" targetFramework="net452" />
 </packages>

--- a/src/SpeechWebServer/Program.cs
+++ b/src/SpeechWebServer/Program.cs
@@ -158,7 +158,31 @@ namespace SpeechWebServer
                         whisper = true;
                     }
 
+                    bool export = false;
+                    if (queryString["export"] != null)
+                    {
+                        bool.TryParse(queryString["export"], out export);
+                    }
+
                     Console.WriteLine("=> " + context.Request.RemoteEndPoint.Address);
+                    if (export)
+                    {
+                        try
+                        {
+                            using (var result = ExportMode(voiceName, engineName, voiceText, location, ep))
+                            {
+                                response.StatusCode = 200;
+                                response.ContentType = "audio/wav";
+                                result.CopyTo(response.OutputStream);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            response.StatusCode = 500;
+                            throw new Exception("Error", ex);
+                        }
+                        continue;
+                    }
 
                     response.StatusCode = 200;
                     response.ContentType = "text/plain; charset=utf-8";
@@ -233,6 +257,20 @@ namespace SpeechWebServer
                 engine.SetPitchRange(ep.PitchRange);
             }
             return engine;
+        }
+
+        private static Stream ExportMode(string libraryName, string engineName, string text, string location, EngineParameters ep)
+        {
+            var engine = ActivateInstance(libraryName, engineName, text, location, ep);
+            if (engine == null)
+            {
+                return null;
+            }
+            engine.Finished += (s, a) =>
+            {
+                engine.Dispose();
+            };
+            return engine.Export(text);
         }
 
         private static void OneShotPlayMode(string libraryName, string engineName, string text, string location, EngineParameters ep)

--- a/src/SpeechWebServer/Program.cs
+++ b/src/SpeechWebServer/Program.cs
@@ -270,7 +270,7 @@ namespace SpeechWebServer
             {
                 engine.Dispose();
             };
-            return engine.Export(text);
+            return engine.ExportToStream(text);
         }
 
         private static void OneShotPlayMode(string libraryName, string engineName, string text, string location, EngineParameters ep)


### PR DESCRIPTION
## 概要

- 音声データをストリームで取得できるようにしました
ISpeechControllerにExportToStreamメソッドを追加しました

- 動機
録音の場合長いテキストのときに時間がかかってしまいます
音声保存インターフェースを使用することで音声合成時間+αの時間で音声データを取得することができます

## 注意点

- VOICEROID2の実装
GUI操作で音声保存ダイアログを操作したりしていてかなりトリッキーです
私の環境では動いていますが他の環境で動かない可能性があると思います
確認環境は日本語版Windows 10 Pro/VOICEROID2 Editor 2.0.5.0, 2.1.1.0です
日本語版以外のWindowsではおそらく動作しません(ファイル保存ダイアログのボタンを見つけられない)
音声出力までに時間がかかるため、私の環境では合成に約2秒以上必要なテキスト(200文字程度)でないと最終的な処理時間が短くなりませんでした

- パッケージの更新
Codeer.Friendly.Windows.NativeStandardControlsの追加にあたって依存パッケージが更新されています

- 未実装の音源
音街ウナTalkは所持していないため実装されていません

- 未テストの音源
CeVIO AIを所持していないためテストできていません
APIはドキュメントを見る限りCeVIOと同様だったのでそのまま実装しています

## テスト環境

Windows 10 Pro 222H2 64bit

- A.I.VOICE
GUMI

- VOICEROID+
京町セイカ
東北きりたん
東北ずん子 EX
民安ともえ EX

- VOICEROID2(32,64bit)
琴葉 茜
琴葉 葵
紲星あかり
結月ゆかり
桜乃そら

- GynoidTalk(32bit)
鳴花ヒメ
鳴花ミコト

- CeVIO(CS6 32bit)
さとうささら
すずきつづみ
タカハシ
ONE
IA

- CeVIO(CS7 64bit)
さとうささら
すずきつづみ
タカハシ

- SAPI5
Microsoft Haruka Desktop

- VOICEVOX
Ver.0.13.3の音源全て

もし興味がありましたら調整や追加実装を手伝っていただけるとありがたいと思っています。