### PR TITLE
VOICEPEAK の出力がターミナルの文字コード設定によって文字化けしないよう修正

### DIFF
--- a/src/Speech/Controller/VOICEPEAKEnumerator.cs
+++ b/src/Speech/Controller/VOICEPEAKEnumerator.cs
@@ -32,6 +32,7 @@ namespace Speech
             psInfo.UseShellExecute = false;
             psInfo.RedirectStandardOutput = true;
             psInfo.Arguments = args;
+            psInfo.StandardOutputEncoding = Encoding.UTF8;
 
             using (Process p = Process.Start(psInfo))
             {


### PR DESCRIPTION
- 動作環境
Windows10 22H2
VOICEPEAK 1.2.3

ターミナルの文字コード設定が UTF-8 以外になっている状態で実行すると
Speech.VOICEPEAKEnumerator.ExecuteVoicepeak() が返す文字列が文字化けする現象を修正しています。